### PR TITLE
Very basic extraction from Coq

### DIFF
--- a/src/Nunchaku_test.v
+++ b/src/Nunchaku_test.v
@@ -2,6 +2,26 @@
 
 Require Import Nunchaku.Nunchaku.
 
+Module pure_logic.
+
+  Goal (False -> False) -> False.
+  Proof.
+    nunchaku.
+  Abort.
+
+End pure_logic.
+
+Module simple_types.
+
+  Definition A := unit.
+
+  Goal (fun x:A => x) = (fun x:A => x).
+  Proof.
+    nunchaku.
+  Qed.
+
+End simple_types.
+
 Section sec1.
 
 Inductive mynat := Z | S : mynat -> mynat.

--- a/src/nunchaku_coq_ast.ml
+++ b/src/nunchaku_coq_ast.ml
@@ -9,16 +9,27 @@ module Nun_id : sig
   type t
   val of_string : string -> t 
   val of_coq_id : Names.Id.t -> t
+  val of_coq_name : Names.Name.t -> t
   val pp : t U.Fmt.printer
   module Set : Set.S with type elt = t
   module Map : Map.S with type key = t
+  val fresh : t -> Set.t -> t
 end = struct
   type t = string
   let of_string s = s
   let of_coq_id = Names.string_of_id
+  let of_coq_name = function
+    | Names.Name.Anonymous -> of_string "_x"
+    | Names.Name.Name id -> of_coq_id id
   let pp = U.Fmt.string
   module Set = Set.Make(String)
   module Map = Map.Make(String)
+
+  let rec fresh id avoid =
+    if Set.mem id avoid then
+      fresh (id^"'") avoid
+    else
+      id
 end
 
 module Builtin : sig


### PR DESCRIPTION
Extracts propositional logic. Treats constants are uninterpreted symbols. Doesn't handle other kinds of symbols yet (`Var`, `Ind`). Doesn't extract definitions from constants. Doesn't extract axioms.

It's really the minimal scheme to demonstrate the approach. I added two example to the Coq file, because the example which was already there isn't handled yet.

Beware: I've pushed some changes to deactivate some parts of the code. You may want to reactivate them at merge.

Next steps:

- Cover all Coq constructs
- First-order quantifiers

Some thoughts for the future:

- The main extraction function should be split into a logic-level and a term-level function
- Extraction of constant definition can be done by the traversal function (just enqueue every constant in some mutable queue, and call extraction until it is empty).
- Constants and inductive should be given polymorphic types.